### PR TITLE
fix: thumbnail copy error when file already exists

### DIFF
--- a/services/image-storage.ts
+++ b/services/image-storage.ts
@@ -202,7 +202,6 @@ export async function saveWorkflowThumbnail({
     }
 
     const thumbnailFile = new File(thumbnailDir, `thumbnail.${ext}`);
-    thumbnailFile.create({ intermediates: true, overwrite: true });
     new File(imageUri).copy(thumbnailFile);
 
     const fileInfo = thumbnailFile.info();


### PR DESCRIPTION
File.copy() in expo-file-system doesn't support overwriting. The previous code called thumbnailFile.create() before copy(), which created an empty file that then caused copy() to fail with 'item with the same name already exists'. Removed the unnecessary create() call since copy() creates the destination file automatically.